### PR TITLE
plan - link component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import './App.css';
 import MainWeb from './pages/MainWeb';
-import Recommendation from './component/Recommendation';
+import Plan from './pages/Plan';
 // import MainMobile from './pages/MainMobile';
 import { Routes, Route } from 'react-router-dom';
 // import useResponsive from './useResponsive';
@@ -9,9 +9,8 @@ function App() {
   // const { isMobile } = useResponsive();
   return (
     <Routes>
-      <Route path="/recommendation" element={<Recommendation />} />
+      <Route path="/plan" element={<Plan />} />
       <Route path="/" element={<MainWeb />}></Route>
-
     </Routes>
   );
 }

--- a/src/component/AddLocation.js
+++ b/src/component/AddLocation.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { /*useEffect,*/ useState } from 'react';
 import './AddLocation.css';
 import { FaPlus } from 'react-icons/fa6';
 import { FiSearch } from 'react-icons/fi';
@@ -7,26 +7,26 @@ const AddLocation = ({ dayPlan, setDayPlan }) => {
   const [places, setPlaces] = useState([]);
   const [keyWord, setKeyWord] = useState('');
 
-  useEffect(() => {
-    const loadKakaoMap = () => {
-      if (window.kakao) {
-        return;
-      }
+  // useEffect(() => {
+  //   const loadKakaoMap = () => {
+  //     if (window.kakao) {
+  //       return;
+  //     }
 
-      const script = document.createElement('script');
-      script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.REACT_APP_KAKAO_API_KEY}&libraries=services&autoload=false`;
-      script.async = true;
-      document.head.appendChild(script);
+  //     const script = document.createElement('script');
+  //     script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.REACT_APP_KAKAO_API_KEY}&libraries=services&autoload=false`;
+  //     script.async = true;
+  //     document.head.appendChild(script);
 
-      script.onload = () => {
-        console.log('Kakao Map API 로드 완료');
-        window.kakao.maps.load(() => {
-          console.log('Kakao Maps Services 로드 완료');
-        });
-      };
-    };
-    loadKakaoMap();
-  });
+  //     script.onload = () => {
+  //       console.log('Kakao Map API 로드 완료');
+  //       window.kakao.maps.load(() => {
+  //         console.log('Kakao Maps Services 로드 완료');
+  //       });
+  //     };
+  //   };
+  //   loadKakaoMap();
+  // });
   const searchPlaces = (keyWord) => {
     if (!window.kakao || !window.kakao.maps) return;
 
@@ -58,8 +58,10 @@ const AddLocation = ({ dayPlan, setDayPlan }) => {
         ...dayPlan,
         {
           id: place.id,
-          categoryGroupName: place.category_group_name,
-          placeName: place.place_name,
+          type: place.category_group_name,
+          name: place.place_name,
+          isReservationNeeded: true,
+          reservationUrl: place.place_url,
         },
       ];
       setDayPlan(updated);

--- a/src/component/Card.js
+++ b/src/component/Card.js
@@ -29,7 +29,7 @@ const Card = ({ item }) => {
           {item.isReservationNeeded && (
             <div
               className="CardButton"
-              onClick={() => window.open('https://www.naver.com', '_blank')}
+              onClick={() => window.open(item.reservationUrl, '_blank')}
             >
               예약하기
             </div>

--- a/src/component/DayList.css
+++ b/src/component/DayList.css
@@ -30,4 +30,6 @@
 }
 .addButton {
   font-weight: 800;
+  background: none;
+  border: none;
 }

--- a/src/component/DayList.js
+++ b/src/component/DayList.js
@@ -1,13 +1,24 @@
 import react from 'react';
+import { useState } from 'react';
 import Card from './Card.js';
 import './DayList.css';
+import Modal from './Modal.js';
+import AddLocation from './AddLocation.js';
 import TransportDuration from './TransportDuration';
 
 function DayList({ day, data }) {
-  const items = data[day - 1] || [];
+  const originItems = data[day - 1] || [];
   const colors = ['#FF4646', '#1CBB39', '#811CBB', 'orange', 'blue'];
   const dayColor = colors[(day - 1) % colors.length];
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [items, setItems] = useState(originItems);
 
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
   return (
     <div className="DayList">
       <div className="DayHeader">
@@ -15,7 +26,10 @@ function DayList({ day, data }) {
           {day}일차
         </div>
         <div className="addPlace">
-          <span className="addButton">+</span> 장소 추가
+          <button className="addButton" onClick={openModal}>
+            {' '}
+            + 장소추가
+          </button>
         </div>
       </div>
       {items.map((item, index) => (
@@ -26,6 +40,9 @@ function DayList({ day, data }) {
           )}
         </react.Fragment>
       ))}
+      <Modal open={isModalOpen} close={closeModal}>
+        <AddLocation dayPlan={items} setDayPlan={setItems} />
+      </Modal>
     </div>
   );
 }

--- a/src/component/Map.js
+++ b/src/component/Map.js
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
-import "./Map.css"; 
+import { useEffect, useRef } from 'react';
+import './Map.css';
 
 const MapComponent = () => {
   const mapRef = useRef(null);
@@ -17,12 +17,15 @@ const MapComponent = () => {
         const baseSize = { width: 64, height: 69 }; // 기본 마커 크기
 
         // 마커 위치
-        const markerPosition = new window.kakao.maps.LatLng(37.5851349, 127.0284268);
+        const markerPosition = new window.kakao.maps.LatLng(
+          37.5851349,
+          127.0284268
+        );
 
         // 마커 이미지 설정 함수
         const GetMarkerImage = (width, height) => {
           return new window.kakao.maps.MarkerImage(
-            process.env.PUBLIC_URL + "/tiger.png",
+            process.env.PUBLIC_URL + '/tiger.png',
             new window.kakao.maps.Size(width, height),
             { offset: new window.kakao.maps.Point(width / 2, height) }
           );
@@ -36,7 +39,7 @@ const MapComponent = () => {
         });
 
         // 줌 변경 이벤트 추가
-        window.kakao.maps.event.addListener(Map, "zoom_changed", () => {
+        window.kakao.maps.event.addListener(Map, 'zoom_changed', () => {
           const currentZoom = Map.getLevel();
           const scale = baseZoomLevel / currentZoom;
           const newSize = {
@@ -47,16 +50,15 @@ const MapComponent = () => {
           // 마커 크기 업데이트
           Marker.setImage(GetMarkerImage(newSize.width, newSize.height));
         });
-
       } else {
-        console.error("카카오맵 API가 로드되지 않았습니다.");
+        console.error('카카오맵 API가 로드되지 않았습니다.');
       }
     };
 
     // 카카오맵 스크립트 로드
     if (!window.kakao || !window.kakao.maps) {
-      const script = document.createElement("script");
-      script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.REACT_APP_KAKAO_API_KEY}&autoload=false`;
+      const script = document.createElement('script');
+      script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.REACT_APP_KAKAO_API_KEY}&libraries=services&autoload=false`;
       script.async = true;
       document.head.appendChild(script);
 
@@ -64,7 +66,7 @@ const MapComponent = () => {
         if (window.kakao && window.kakao.maps) {
           window.kakao.maps.load(InitMap);
         } else {
-          console.error("카카오맵 API가 정상적으로 로드되지 않았습니다.");
+          console.error('카카오맵 API가 정상적으로 로드되지 않았습니다.');
         }
       };
     } else {
@@ -73,10 +75,10 @@ const MapComponent = () => {
   }, []);
 
   return (
-    <div className="mapViewContainer"> 
+    <div className="mapViewContainer">
       <div className="mapBox" ref={mapRef}></div>
     </div>
-  );  
+  );
 };
 
 export default MapComponent;

--- a/src/component/Recommendation.js
+++ b/src/component/Recommendation.js
@@ -20,9 +20,22 @@ const Recommendation = () => {
   }, []);
   return (
     <div>
-      {Array.from({ length: day }, (_, index) => (
-        <DayList key={index + 1} day={index + 1} data={data} />
-      ))}
+      <ul
+        style={{
+          height: '100vh', // 원하는 높이로 조정
+          overflowY: 'auto',
+          padding: 0,
+          margin: 0,
+          listStyle: 'none',
+          border: '1px solid #ddd', // 선택사항
+        }}
+      >
+        {Array.from({ length: day }, (_, index) => (
+          <li key={index + 1}>
+            <DayList day={index + 1} data={data} />
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/src/pages/MainWeb.js
+++ b/src/pages/MainWeb.js
@@ -1,44 +1,14 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import ScheduleContainer from '../components/Schedule/ScheduleContainer';
-import AddLocation from '../component/AddLocation.js';
-import { useState, useEffect } from 'react';
-import Modal from '../component/Modal.js';
 
 const MainWeb = () => {
-  const [dayPlan, setDayPlan] = useState([]);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const openModal = () => {
-    setIsModalOpen(true);
-  };
-  const closeModal = () => {
-    setIsModalOpen(false);
-  };
-
-  useEffect(() => {
-    setDayPlan([
-      {
-        id: '16617901',
-        categoryGroupName: '음식점',
-        placeName: '본죽&비빔밥cafe 고려대점',
-      },
-      {
-        id: '512026481',
-        categoryGroupName: '카페페',
-        placeName: '메가MGC커피 고대점',
-      },
-    ]);
-  }, []);
+  const navigate = useNavigate();
   return (
     <div>
       this is web
       <ScheduleContainer />
-      <button onClick={openModal}>장소 추가</button>
-      <button onClick={() => navigate('/recommendation')}>추천받기</button>
-      <Modal open={isModalOpen} close={closeModal}>
-        <AddLocation dayPlan={dayPlan} setDayPlan={setDayPlan} />
-      </Modal>
+      <button onClick={() => navigate('/plan')}>plan</button>
     </div>
   );
 };

--- a/src/pages/Plan.js
+++ b/src/pages/Plan.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import Map from '../component/Map';
+import Recommendation from '../component/Recommendation';
+
+const Plan = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+      }}
+    >
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <Map />
+      </div>
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <Recommendation />
+      </div>
+    </div>
+  );
+};
+
+export default Plan;


### PR DESCRIPTION
Map, Recommendation, AddLocation 연결

MainWeb 에 Plan 버튼 생성 -> App.js에 /recommendation 대신 /plan 경로 추가해서
버튼 누르면 plan으로 넘어가도록 했습니다.

-Map
Map은 아직 data 받는 param이 없는 것 같아서 plan page에 띄워놓기만 했습니다.

-Recommendation

recommendation 부분 영역을 정해놓고 그 안에서 스크롤 되게 하는 게 나중에 드래그앤드랍 & delete할 때
편할 것 같아서 바꿔놨습니다.

장소 추가 버튼 연결

kakao api 검색 기능 사용하면 그 장소에 대한 kakao map url을 받아올 수 있어서 reservationUrl에 일단 그걸 넘겨줬습니다.


해결해야할 부분
1. 현재 Map, Recommendation 모두 css가 반응형으로 짜여있지 않음

2. mockdata 형식이 지금은 array로 되어있는데 object로 바뀐다면 recommendation에 띄우기 전에 전처리 필요 

3. kakaomap api 불러오는 걸 main에서 한 번만 실행해야할 것 같음. 
현재 Map, 장소추가 검색에서 두 번 api를 불러와 문제가 발생하여 Map에 있는 코드만 살려놨음.
나중에 서버에서 api를 불러올 수 있게 되면 web이 렌더링될 때 한 번만 호출하도록 바꿔야할 듯